### PR TITLE
adds batch() and chain() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ class LongRunningAction{
 Failed action jobs can be handled by defining a `jobFailed()` method:
 
 ```php
-use Illuminate\Support\Facades\Mail;class LongRunningAction{
+class LongRunningAction{
     use ActsAsJob;
        
     public function handle(){..}
@@ -154,6 +154,17 @@ use Illuminate\Support\Facades\Mail;class LongRunningAction{
     
     private function handleFailure(){..}
 }
+```
+
+### Batches and Chains of action jobs
+
+Similarly to the `runMany()` method, a new batch/chain of action jobs can be created starting from an array of parameters:
+
+```php
+
+MyAction::batch([$name1, $title1], [$name2, $title2])->dispatch();
+
+MyAction::chain([$name1, $title1], [$name2, $title2])->dispatch();
 ```
 
 

--- a/src/Concerns/ActsAsJob.php
+++ b/src/Concerns/ActsAsJob.php
@@ -1,9 +1,15 @@
 <?php
 
+/** @noinspection PhpUnnecessaryLocalVariableInspection */
+
 namespace DefStudio\Actions\Concerns;
 
 use DefStudio\Actions\Jobs\ActionJob;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Foundation\Bus\PendingDispatch;
+use Illuminate\Support\Facades\Bus;
+use ReflectionMethod;
 
 trait ActsAsJob
 {
@@ -20,5 +26,39 @@ trait ActsAsJob
     public static function dispatchAfterResponse(mixed ...$args): PendingDispatch
     {
         return self::dispatch(...$args)->afterResponse();
+    }
+
+    public static function batch(mixed ...$args): PendingBatch
+    {
+        return Bus::batch(self::buildJobArray(...$args));
+    }
+
+    public static function chain(mixed ...$args): PendingChain
+    {
+        return Bus::chain(self::buildJobArray(...$args));
+    }
+
+    /**
+     * @return ActionJob[]
+     */
+    private static function buildJobArray(mixed ...$args): array
+    {
+        /** @var ActionJob[] $jobs */
+        $jobs = collect($args)
+            ->map(function (mixed $jobArgs): ActionJob {
+                if (!is_array($jobArgs)) {
+                    return static::job($jobArgs);
+                }
+
+                $reflection = new ReflectionMethod(static::class, 'handle');
+
+                if ($reflection->getNumberOfParameters() > 1) {
+                    return static::job(...$jobArgs);
+                }
+
+                return static::job($jobArgs);
+            })->toArray();
+
+        return $jobs;
     }
 }

--- a/tests/Unit/Concerns/InjectsItselfTest.php
+++ b/tests/Unit/Concerns/InjectsItselfTest.php
@@ -106,7 +106,7 @@ it('can run itself multiple times', function ($class, $parameters, $result) {
         'parameters' => [['a' => 4, 'b' => 2], ['b' => 4]],
         'result'     => [2, 0.25],
     ],
-    'detault parameters' => [
+    'default parameters' => [
         'class' => new class() {
             use InjectsItself;
 


### PR DESCRIPTION
implements `batch()` and `chain()` methods to create a batch/chain of job executing the action handle method:

```php

MyAction::batch([$name1, $title1], [$name2, $title2])->dispatch();

MyAction::chain([$name1, $title1], [$name2, $title2])->dispatch();
```

close #2 