### PR TITLE
implements spy testing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ without arguments, `mocks` returns a MockInterface instance ready to be used
 MyAction::mock()->shouldNotReceive('handle');
 ```
 
+along with mocks, actions can also be _spied_:
+
+```php
+$spiedAction = MyAction::spy();
+
+$spiedAction->handle();
+$spiedAction->handle();
+
+$spiedAction->shouldHaveReceived()->handle()->twice()
+```
+
 ## Dispatchable actions
 
 An action can be made _dispatchable_ as a job with the `ActsAsJob` trait (or extending the `Action` class)

--- a/src/Concerns/MocksItsBehaviour.php
+++ b/src/Concerns/MocksItsBehaviour.php
@@ -6,6 +6,7 @@ namespace DefStudio\Actions\Concerns;
 
 use DefStudio\Actions\Exceptions\ActionException;
 use Illuminate\Support\Collection;
+use Mockery;
 use Mockery\MockInterface;
 
 trait MocksItsBehaviour
@@ -41,5 +42,14 @@ trait MocksItsBehaviour
         app()->bind(static::class, fn () => $mock);
 
         return $mock;
+    }
+
+    public static function spy(): static|MockInterface|Mockery\LegacyMockInterface
+    {
+        $spy = Mockery::spy(static::class);
+
+        app()->bind(static::class, fn () => $spy);
+
+        return $spy;
     }
 }

--- a/tests/Unit/Concerns/MocksItsBehaviourTest.php
+++ b/tests/Unit/Concerns/MocksItsBehaviourTest.php
@@ -74,3 +74,21 @@ it('can quickly mock all its methods', function () {
     expect($instance->handle())->toBe('"handle" mocked successfully');
     expect($instance->execute())->toBe('"execute" mocked successfully');
 });
+
+it('can spy its behaviour', function () {
+    $class = new class() {
+        use MocksItsBehaviour;
+
+        public function handle(): string
+        {
+            return 'was actually called';
+        }
+    };
+
+    $spy = $class::spy();
+
+    $spy->handle();
+
+    $spy->shouldHaveReceived()
+        ->handle();
+});


### PR DESCRIPTION
Allows ` $spied_action = MyAction::spy()`