### PR TITLE
adds jobFailed method

### DIFF
--- a/src/Concerns/ActsAsJob.php
+++ b/src/Concerns/ActsAsJob.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\PendingChain;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Support\Facades\Bus;
 use ReflectionMethod;
+use Throwable;
 
 trait ActsAsJob
 {
@@ -60,5 +61,9 @@ trait ActsAsJob
             })->toArray();
 
         return $jobs;
+    }
+
+    public function jobFailed(Throwable $exception): void
+    {
     }
 }


### PR DESCRIPTION
this PR will add a new empty `jobFailed` method to the `ActsAsJob` trait, in order to hint its definition in action class through an override